### PR TITLE
Fix README for Day 5

### DIFF
--- a/Month-1/Week-1/day-05/README.md
+++ b/Month-1/Week-1/day-05/README.md
@@ -11,7 +11,7 @@ SockPairs("AA") ➞ 1
 
 SockPairs("ABABC") ➞ 2
 
-SockPairs("CABBACCC") ➞ 5
+SockPairs("CABBACCC") ➞ 4
 ```
 
 ---


### PR DESCRIPTION
The README for the Day-5 challenge erroneously claimed that the string
"CABBACCC" denotes 5 pairs of socks. This should be 4 (1x "AA", 1x "BB",
2x "CC").